### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE-EPL-OTP
+++ b/LICENSE-EPL-OTP
@@ -274,7 +274,7 @@ EXHIBIT A.
 Version 1.1, (the "License"); you may not use this file except in
 compliance with the License. You should have received a copy of the
 Erlang Public License along with this software. If not, it can be
-retrieved via the world wide web at http://www.erlang.org/.
+retrieved via the world wide web at https://www.erlang.org/.
 
 Software distributed under the License is distributed on an "AS IS"
 basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See

--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ SockJS family:
 SockJS-erlang server
 ====================
 
-[SockJS](http://sockjs.org) server written in Erlang. Can run with
+[SockJS](https://github.com/sockjs/sockjs-client) server written in Erlang. Can run with
 [Cowboy](https://github.com/extend/cowboy) http server. SockJS-erlang
 is in core web-framework agnostic (up to version
 [v0.2.1](https://github.com/sockjs/sockjs-erlang/tree/v0.2.1 ) we also
 supported
 [Misultin](https://github.com/ostinelli/misultin)). SockJS-erlang is
 compatible with
-[SockJS client version 0.3](http://sockjs.github.com/sockjs-protocol/sockjs-protocol-0.3.html). See
+[SockJS client version 0.3](https://sockjs.github.com/sockjs-protocol/sockjs-protocol-0.3.html). See
 https://github.com/sockjs/sockjs-client for more information on
 SockJS.
 

--- a/examples/echo.html
+++ b/examples/echo.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html><head>
-  <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.6.2/jquery.min.js">
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.2/jquery.min.js">
   </script>
   <script src="http://cdn.sockjs.org/sockjs-0.3.4.min.js">
   </script>

--- a/examples/echo_authen_callback.html
+++ b/examples/echo_authen_callback.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html><head>
-  <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.6.2/jquery.min.js">
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.6.2/jquery.min.js">
   </script>
   <script src="http://cdn.sockjs.org/sockjs-0.3.4.min.js">
   </script>

--- a/examples/multiplex/index.html
+++ b/examples/multiplex/index.html
@@ -1,8 +1,8 @@
 <!doctype html>
 <html><head>
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
     <script src="http://cdn.sockjs.org/sockjs-0.3.min.js"></script>
-    <script src="http://d1fxtkz8shb9d2.cloudfront.net/websocket-multiplex-0.1.js"></script>
+    <script src="https://d1fxtkz8shb9d2.cloudfront.net/websocket-multiplex-0.1.js"></script>
     <style>
       .box {
           width: 300px;

--- a/examples/multiplex/index_authen_callback.html
+++ b/examples/multiplex/index_authen_callback.html
@@ -1,8 +1,8 @@
 <!doctype html>
 <html><head>
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
     <script src="http://cdn.sockjs.org/sockjs-0.3.min.js"></script>
-    <script src="http://d1fxtkz8shb9d2.cloudfront.net/websocket-multiplex-0.1.js"></script>
+    <script src="https://d1fxtkz8shb9d2.cloudfront.net/websocket-multiplex-0.1.js"></script>
     <style>
       .box {
           width: 300px;

--- a/src/mochinum_fork.erl
+++ b/src/mochinum_fork.erl
@@ -4,7 +4,7 @@
 %% @doc Useful numeric algorithms for floats that cover some deficiencies
 %% in the math module. More interesting is digits/1, which implements
 %% the algorithm from:
-%% http://www.cs.indiana.edu/~burger/fp/index.html
+%% https://cs.indiana.edu/~burger/fp/index.html
 %% See also "Printing Floating-Point Numbers Quickly and Accurately"
 %% in Proceedings of the SIGPLAN '96 Conference on Programming Language
 %% Design and Implementation.

--- a/src/sockjs_action.erl
+++ b/src/sockjs_action.erl
@@ -91,7 +91,7 @@ xhr_streaming(Req, Headers, Service = #service{response_limit = ResponseLimit},
               Session) ->
     Req1 = chunk_start(Req, Headers),
     %% IE requires 2KB prefix:
-    %% http://blogs.msdn.com/b/ieinternals/archive/2010/04/06/comet-streaming-in-internet-explorer-with-xmlhttprequest-and-xdomainrequest.aspx
+    %% https://blogs.msdn.com/b/ieinternals/archive/2010/04/06/comet-streaming-in-internet-explorer-with-xmlhttprequest-and-xdomainrequest.aspx
     Req2 = chunk(Req1, list_to_binary(string:copies("h", 2048)),
                  fun fmt_xhr/1),
     reply_loop(Req2, Session, ResponseLimit, fun fmt_xhr/1, Service).
@@ -112,7 +112,7 @@ htmlfile(Req, Headers, Service = #service{response_limit = ResponseLimit},
                 IFrame = iolist_to_binary(io_lib:format(?IFRAME_HTMLFILE, [CB])),
                 %% Safari needs at least 1024 bytes to parse the
                 %% website. Relevant:
-                %%   http://code.google.com/p/browsersec/wiki/Part2#Survey_of_content_sniffing_behaviors
+                %%   https://code.google.com/p/browsersec/wiki/Part2#Survey_of_content_sniffing_behaviors
                 Padding = string:copies(" ", 1024 - size(IFrame)),
                 Req3 = chunk(Req2, [IFrame, Padding, <<"\r\n\r\n">>]),
                 reply_loop(Req3, SessionId, ResponseLimit, fun fmt_htmlfile/1, Service)


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://cdn.sockjs.org/sockjs-0.2.min.js (200) with 1 occurrences could not be migrated:  
   ([https](https://cdn.sockjs.org/sockjs-0.2.min.js) result SSLHandshakeException).
* http://cdn.sockjs.org/sockjs-0.3.4.min.js (200) with 2 occurrences could not be migrated:  
   ([https](https://cdn.sockjs.org/sockjs-0.3.4.min.js) result SSLHandshakeException).
* http://cdn.sockjs.org/sockjs-0.3.min.js (200) with 2 occurrences could not be migrated:  
   ([https](https://cdn.sockjs.org/sockjs-0.3.min.js) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://sockjs.org (303) with 1 occurrences migrated to:  
  https://github.com/sockjs/sockjs-client ([https](https://sockjs.org) result AnnotatedConnectException).
* http://www.cs.indiana.edu/~burger/fp/index.html (301) with 1 occurrences migrated to:  
  https://cs.indiana.edu/~burger/fp/index.html ([https](https://www.cs.indiana.edu/~burger/fp/index.html) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://ajax.googleapis.com/ajax/libs/jquery/1.6.2/jquery.min.js with 2 occurrences migrated to:  
  https://ajax.googleapis.com/ajax/libs/jquery/1.6.2/jquery.min.js ([https](https://ajax.googleapis.com/ajax/libs/jquery/1.6.2/jquery.min.js) result 200).
* http://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js with 2 occurrences migrated to:  
  https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js ([https](https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js) result 200).
* http://d1fxtkz8shb9d2.cloudfront.net/websocket-multiplex-0.1.js with 2 occurrences migrated to:  
  https://d1fxtkz8shb9d2.cloudfront.net/websocket-multiplex-0.1.js ([https](https://d1fxtkz8shb9d2.cloudfront.net/websocket-multiplex-0.1.js) result 200).
* http://www.erlang.org/ with 1 occurrences migrated to:  
  https://www.erlang.org/ ([https](https://www.erlang.org/) result 200).
* http://blogs.msdn.com/b/ieinternals/archive/2010/04/06/comet-streaming-in-internet-explorer-with-xmlhttprequest-and-xdomainrequest.aspx with 1 occurrences migrated to:  
  https://blogs.msdn.com/b/ieinternals/archive/2010/04/06/comet-streaming-in-internet-explorer-with-xmlhttprequest-and-xdomainrequest.aspx ([https](https://blogs.msdn.com/b/ieinternals/archive/2010/04/06/comet-streaming-in-internet-explorer-with-xmlhttprequest-and-xdomainrequest.aspx) result 301).
* http://code.google.com/p/browsersec/wiki/Part2 with 1 occurrences migrated to:  
  https://code.google.com/p/browsersec/wiki/Part2 ([https](https://code.google.com/p/browsersec/wiki/Part2) result 301).
* http://sockjs.github.com/sockjs-protocol/sockjs-protocol-0.3.html with 1 occurrences migrated to:  
  https://sockjs.github.com/sockjs-protocol/sockjs-protocol-0.3.html ([https](https://sockjs.github.com/sockjs-protocol/sockjs-protocol-0.3.html) result 301).

# Ignored
These URLs were intentionally ignored.

* http://localhost:8080/ with 2 occurrences
* http://localhost:8081 with 2 occurrences
* http://localhost:~p~n with 5 occurrences